### PR TITLE
Change install script ot use composer image instead of composer/composer

### DIFF
--- a/install
+++ b/install
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 docker pull php:7.3-cli
-docker pull composer/composer
-docker run --rm -v $(pwd):/app composer/composer install
+docker pull composer
+docker run --rm -v $(pwd):/app composer install

--- a/install
+++ b/install
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 docker pull php:7.3-cli
 docker pull composer/composer
 docker run --rm -v $(pwd):/app composer/composer install

--- a/runtest
+++ b/runtest
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 docker run -it --rm --name diconvergence -v "$PWD":/usr/src/myapp -w /usr/src/myapp php:7.3-cli vendor/phpunit/phpunit/phpunit -c phpunit.xml.dist


### PR DESCRIPTION
The composer/composer image is outdated and runs on php 7.0.7, while
doctrine/instantiator requires ^7.1.

The lastest composer image however has php 7.4 installed.

In addition I added some shebangs to the `install` and `runtest` scripts so that I can run them using fish shell.

See you tomorrow! :)